### PR TITLE
Support Fedora 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Desktop Deploy
 
-* Ansible script to deploy a Fedora 34 host.
+* Ansible script to deploy a Fedora 35 host.
 
 
 ## Running

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
   - name: Fedora
     versions:
     - 34
+    - 35
   #   - 25
   # - name: SomePlatform
   #   versions:

--- a/roles/common/molecule/default/molecule.yml
+++ b/roles/common/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/desktop/meta/main.yml
+++ b/roles/desktop/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
   - name: Fedora
     versions:
     - 34
+    - 35
   #   - 25
   # - name: SomePlatform
   #   versions:

--- a/roles/desktop/molecule/default/molecule.yml
+++ b/roles/desktop/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/dev/meta/main.yml
+++ b/roles/dev/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
   - name: Fedora
     versions:
     - 34
+    - 35
   #   - 25
   # - name: SomePlatform
   #   versions:

--- a/roles/dev/molecule/default/molecule.yml
+++ b/roles/dev/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/fuzzing/meta/main.yml
+++ b/roles/fuzzing/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: PentesterWTF
-  description: Installs common fuzzing utilities on Fedora 34
+  description: Installs common fuzzing utilities on Fedora 35
   role_name: fuzzing
   namespace: pentesterwtf
 
@@ -32,6 +32,7 @@ galaxy_info:
   - name: Fedora
     versions:
     - 34
+    - 35
   #   - 25
   # - name: SomePlatform
   #   versions:

--- a/roles/fuzzing/molecule/default/molecule.yml
+++ b/roles/fuzzing/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/hashicorp/meta/main.yml
+++ b/roles/hashicorp/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
   - name: Fedora
     versions:
     - 34
+    - 35
   # - name: SomePlatform
   #   versions:
   #   - all

--- a/roles/hashicorp/molecule/default/molecule.yml
+++ b/roles/hashicorp/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/recon/meta/main.yml
+++ b/roles/recon/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
   - name: Fedora
     versions:
     - 34
+    - 35
   #   - 25
   # - name: SomePlatform
   #   versions:

--- a/roles/recon/molecule/default/molecule.yml
+++ b/roles/recon/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/reveng/meta/main.yml
+++ b/roles/reveng/meta/main.yml
@@ -32,6 +32,7 @@ galaxy_info:
   - name: Fedora
     versions:
     - 34
+    - 35
   #   - 25
   # - name: SomePlatform
   #   versions:

--- a/roles/reveng/molecule/default/molecule.yml
+++ b/roles/reveng/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible

--- a/roles/vscode/README.md
+++ b/roles/vscode/README.md
@@ -1,7 +1,7 @@
 Visual Studio Code
 =========
 
-Installs visual studio code on Fedora 34+
+Installs visual studio code on Fedora 35+
 
 License
 -------

--- a/roles/vscode/molecule/default/molecule.yml
+++ b/roles/vscode/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: podman
 platforms:
   - name: instance
-    image: docker.io/fedora:34
+    image: docker.io/fedora:35
     pre_build_image: true
 provisioner:
   name: ansible


### PR DESCRIPTION
Work to suppport Fedora 35.
Currently this works on Fedora 34, which is no longer latest
https://github.com/pentesterwtf/ansible-desktop/issues/27